### PR TITLE
Fix issue #8: `dir.Glob()` with explicit filename

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,12 @@
+# v0.6.2
+
+- `dir.Glob()` and associated function can now match patterns that are an
+  explicit filename instead of a glob pattern.
+
+# v0.6.1
+
+- Code cleanup, no changes
+
 # v0.6.0
 
 ## Major changes

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.17
 
 require (
 	github.com/maargenton/go-errors v1.0.0
-	github.com/maargenton/go-testpredicate v1.0.0
-	github.com/pmezard/go-difflib v1.0.0
+	github.com/maargenton/go-testpredicate v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,9 +4,8 @@ github.com/maargenton/go-errors v1.0.0 h1:gNDwTfN3VHwLog2w/BfeGlCTjwjJ6H0NeMKS+4
 github.com/maargenton/go-errors v1.0.0/go.mod h1:yVvhNp6mywh/FFoTYbi2WPH7oP0U9AZXtvGa8SDIxOQ=
 github.com/maargenton/go-testpredicate v0.4.4/go.mod h1:sn267JpJ65uvLQ7VtYzPLvXQiw0tHHw+KbCFzxRPOww=
 github.com/maargenton/go-testpredicate v0.6.4/go.mod h1:lUPR99Ipl1o49oRb5wEUwb/7KXrwc1FAVR6aZmCmoS8=
-github.com/maargenton/go-testpredicate v1.0.0 h1:8dimey5rt3kbqTFADidZYnbdnLfjWTyYD3vitM77q4s=
-github.com/maargenton/go-testpredicate v1.0.0/go.mod h1:ZscqHa6PT35rm0psZd9y1KV6ygPL1C5NfDFBDFTkGu8=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/maargenton/go-testpredicate v1.3.0 h1:uy9g71epeAmI2CXHnEYKFDwueXppvLHZMoUfAF82K9o=
+github.com/maargenton/go-testpredicate v1.3.0/go.mod h1:ZscqHa6PT35rm0psZd9y1KV6ygPL1C5NfDFBDFTkGu8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/dir/glob.go
+++ b/pkg/dir/glob.go
@@ -8,12 +8,11 @@ import (
 	"strings"
 
 	"github.com/maargenton/go-fileutils"
-	// "golang.org/x/tools/internal/fastwalk"
 )
 
-// Glob scans the file tree and returns a list of filenames matching the
-// pattern. The pattern must be specified according to the extended glob pattern
-// described in the package level documentation.
+// Glob scans the file tree and returns a list of filenames matching `pattern`
+// which must be specified according to the extended glob pattern described in
+// this package.
 func Glob(pattern string) (matches []string, err error) {
 	m, err := NewGlobMatcher(pattern)
 	if err != nil {
@@ -22,12 +21,12 @@ func Glob(pattern string) (matches []string, err error) {
 	return m.Glob()
 }
 
-// GlobFrom scans the file tree starting at basepath and returns a list of
-// filenames matching the pattern. The resulting filenames contain the full path
-// including the basepath prefix. The pattern should be relative and must be
-// specified according to the extended glob pattern described in the package
-// level documentation. If the pattern is absolute, the basepath is ignored and
-// will not appear as a prefix in the matches.
+// GlobFrom scans the file tree starting at `basepath` and returns a list of
+// filenames matching `pattern`, which must be specified according to the
+// extended glob pattern described in this package. If the pattern is relative,
+// the resulting filenames are relative to `basepath`. If the pattern is
+// absolute, the basepath is ignored and the the resulting filenames are
+// absolute.
 func GlobFrom(basepath, pattern string) (matches []string, err error) {
 	m, err := NewGlobMatcher(pattern)
 	if err != nil {
@@ -36,9 +35,9 @@ func GlobFrom(basepath, pattern string) (matches []string, err error) {
 	return m.GlobFrom(basepath)
 }
 
-// Scan scans the file tree for filenames matching the pattern and call the
-// walkFn function for every match. The pattern must be specified according to
-// the extended glob pattern described in the package level documentation.
+// Scan scans the file tree for filenames matching `pattern` and calls `walkFn`
+// for every match. The pattern must be specified according to the extended glob
+// pattern described in the package level documentation.
 func Scan(pattern string, walkFn fs.WalkDirFunc) error {
 	m, err := NewGlobMatcher(pattern)
 	if err != nil {
@@ -47,12 +46,12 @@ func Scan(pattern string, walkFn fs.WalkDirFunc) error {
 	return m.Scan(walkFn)
 }
 
-// ScanFrom scans the file tree starting at basepath for filenames matching the
-// pattern and call the walkFn function for every match. The resulting filenames
-// contain the full path including the basepath prefix. The pattern should be
-// relative and must be specified according to the extended glob pattern
-// described in the package level documentation. If the pattern is absolute, the
-// basepath is ignored and will not appear as a prefix in the matches.
+// ScanFrom scans the file tree starting at `basepath` for filenames matching
+// `pattern` and calls `walkFn` for every match. The pattern must be specified
+// according to the extended glob pattern described in this package. If the
+// pattern is relative, filenames are reported relative to `basepath`. If the
+// pattern is absolute, the basepath is ignored and filenames are reported with
+// an absolute path.
 func ScanFrom(basepath, pattern string, walkFn fs.WalkDirFunc) error {
 	m, err := NewGlobMatcher(pattern)
 	if err != nil {
@@ -97,7 +96,7 @@ func NewGlobMatcher(pattern string) (m *GlobMatcher, err error) {
 			})
 			subdir = false
 		} else {
-			if prefix {
+			if prefix && len(fragments) > 0 {
 				m.prefix = fileutils.Join(m.prefix, fragment)
 			} else {
 				m.fragments = append(m.fragments, globFragment{

--- a/pkg/dir/glob.go
+++ b/pkg/dir/glob.go
@@ -107,11 +107,6 @@ func NewGlobMatcher(pattern string) (m *GlobMatcher, err error) {
 			}
 		}
 	}
-
-	if m.prefix != "" && !strings.HasSuffix(m.prefix, string(fileutils.Separator)) {
-		m.prefix += string(fileutils.Separator)
-	}
-
 	return
 }
 

--- a/pkg/dir/glob_test.go
+++ b/pkg/dir/glob_test.go
@@ -120,6 +120,7 @@ func TestGlob(t *testing.T) {
 		{`src/**/*_test.{c,cc,cpp}`, 4},
 		{`src/**/*_test.{h,hh,hpp}`, 0},
 		{`src/**/*.{h,cpp}`, 12},
+		{`src/foo/foo.cpp`, 1},
 	}
 
 	basepath, cleanup, err := setupTestFolder()
@@ -168,6 +169,12 @@ func TestGlobFromSystemRoot(t *testing.T) {
 	}
 }
 
+func TestGlobExplicit(t *testing.T) {
+	matches, err := dir.Glob("glob_test.go")
+	require.That(t, err).IsNil()
+	require.That(t, matches).Eq([]string{"glob_test.go"})
+}
+
 // func TestGlobFromSystemRoot2(t *testing.T) {
 // 	matches, err := dir.Glob("/dev/std*")
 // 	require.That(t, err).IsNil()
@@ -180,7 +187,7 @@ func TestGlobFromSystemRoot(t *testing.T) {
 // ---------------------------------------------------------------------------
 // dir.GlobFrom()
 
-func TestGlobMatcherGlobFrom(t *testing.T) {
+func TestGlobFrom(t *testing.T) {
 	var tcs = []struct {
 		pattern string
 		count   int
@@ -190,6 +197,7 @@ func TestGlobMatcherGlobFrom(t *testing.T) {
 		{`src/**/*_test.{c,cc,cpp}`, 4},
 		{`src/**/*_test.{h,hh,hpp}`, 0},
 		{`src/**/*.{h,cpp}`, 12},
+		{`src/foo/foo.cpp`, 1},
 	}
 	basepath, cleanup, err := setupTestFolder()
 	require.That(t, err).IsNil()
@@ -207,11 +215,17 @@ func TestGlobMatcherGlobFrom(t *testing.T) {
 	}
 }
 
+func TestGlobFromExplicit(t *testing.T) {
+	matches, err := dir.GlobFrom("..", "dir/glob_test.go")
+	require.That(t, err).IsNil()
+	require.That(t, matches).Eq([]string{"dir/glob_test.go"})
+}
+
 // dir.GlobFrom()
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// dir.Glob()
+// dir.Scan()
 
 func TestScan(t *testing.T) {
 	var tcs = []struct {

--- a/pkg/dir/glob_test.go
+++ b/pkg/dir/glob_test.go
@@ -25,6 +25,14 @@ func TestNewGlobMatcherError(t *testing.T) {
 	require.That(t, m).IsNil()
 }
 
+func TestNewGlobMatcherExplicitFilename(t *testing.T) {
+	pattern := `index.html`
+	m, err := dir.NewGlobMatcher(pattern)
+	require.That(t, err).IsError(nil)
+	require.That(t, m).IsNotNil()
+	require.That(t, m.Match("index.html")).IsTrue()
+}
+
 // dir.NewGlobMatcher()
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- Update package dependencies
- Clarify documentation; filenames returned by `GlobFrom()` / `ScanFrom()` are relative to specified `basepath`